### PR TITLE
feat(frontend): add navbar, driver stats panel, and login form

### DIFF
--- a/frontend/public/placeholder.svg
+++ b/frontend/public/placeholder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400"><rect width="400" height="400" fill="#ccc"/></svg>

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -3,6 +3,8 @@ import { useAuth } from '../context/AuthContext';
 import io from 'socket.io-client';
 import TelemetryPanel from './TelemetryPanel';
 import LapTimeChart from './LapTimeChart';
+import Navbar from './Navbar';
+import DriverStats from './DriverStats';
 
 export default function Dashboard() {
   const { token } = useAuth();
@@ -45,19 +47,21 @@ export default function Dashboard() {
 
   return (
     <div className="p-4 space-y-4">
-      <div className="flex items-center space-x-2">
-        <input
-          className="text-black p-2"
-          value={favoriteDriver}
-          onChange={(e) => setFavoriteDriver(e.target.value)}
-          placeholder="Driver number e.g. 1"
+      <Navbar
+        favoriteDriver={favoriteDriver}
+        onFavoriteChange={setFavoriteDriver}
+        onSave={handleSave}
+      />
+      <div className="grid grid-cols-2 gap-4 auto-rows-fr">
+        <DriverStats
+          favoriteDriver={favoriteDriver}
+          lap={laps.length ? laps[laps.length - 1] : null}
         />
-        <button className="bg-red-600 px-3 py-2 rounded" onClick={handleSave}>
-          Save
-        </button>
+        <TelemetryPanel telemetry={telemetry} />
+        <div className="col-span-2">
+          <LapTimeChart laps={laps} />
+        </div>
       </div>
-      <TelemetryPanel telemetry={telemetry} />
-      <LapTimeChart laps={laps} />
     </div>
   );
 }

--- a/frontend/src/components/DriverStats.jsx
+++ b/frontend/src/components/DriverStats.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function DriverStats({ favoriteDriver, lap }) {
+  return (
+    <div className="bg-gray-800 p-4 rounded flex flex-col justify-center h-full">
+      <h2 className="text-xl mb-2">Driver #{favoriteDriver || 'N/A'}</h2>
+      <div className="space-y-1">
+        <div>Last Lap: {lap ? lap.lap_number : 'N/A'}</div>
+        <div>Last Lap Time: {lap ? lap.lap_time : 'N/A'}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { cn } from '../lib/utils';
+import { Button } from './ui/button';
+import { Card, CardContent } from './ui/card';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { useAuth } from '../context/AuthContext';
+
+export default function LoginForm({ className, ...props }) {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('demo');
+  const [password, setPassword] = useState('password');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:3000/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: email, password })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      login(data.token);
+    } else {
+      alert('Login failed');
+    }
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-6', className)} {...props}>
+      <Card className="overflow-hidden">
+        <CardContent className="grid p-0 md:grid-cols-2">
+          <form className="p-6 md:p-8" onSubmit={handleSubmit}>
+            <div className="flex flex-col gap-6">
+              <div className="flex flex-col items-center text-center">
+                <h1 className="text-2xl font-bold">Welcome back</h1>
+                <p className="text-balance text-muted-foreground">Login to your Acme Inc account</p>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" type="email" placeholder="m@example.com" required value={email} onChange={(e) => setEmail(e.target.value)} />
+              </div>
+              <div className="grid gap-2">
+                <div className="flex items-center">
+                  <Label htmlFor="password">Password</Label>
+                  <a href="#" className="ml-auto text-sm underline-offset-2 hover:underline">
+                    Forgot your password?
+                  </a>
+                </div>
+                <Input id="password" type="password" required value={password} onChange={(e) => setPassword(e.target.value)} />
+              </div>
+              <Button type="submit" className="w-full">
+                Login
+              </Button>
+              <div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t after:border-border">
+                <span className="relative z-10 bg-background px-2 text-muted-foreground">Or continue with</span>
+              </div>
+              <div className="grid grid-cols-3 gap-4">
+                <Button variant="outline" className="w-full">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <path
+                      d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span className="sr-only">Login with Apple</span>
+                </Button>
+                <Button variant="outline" className="w-full">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <path
+                      d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span className="sr-only">Login with Google</span>
+                </Button>
+                <Button variant="outline" className="w-full">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <path
+                      d="M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a6.624 6.624 0 0 0 .265.86 5.297 5.297 0 0 0 .371.761c.696 1.159 1.818 1.927 3.593 1.927 1.497 0 2.633-.671 3.965-2.444.76-1.012 1.144-1.626 2.663-4.32l.756-1.339.186-.325c.061.1.121.196.183.3l2.152 3.595c.724 1.21 1.665 2.556 2.47 3.314 1.046.987 1.992 1.22 3.06 1.22 1.075 0 1.876-.355 2.455-.843a3.743 3.743 0 0 0 .81-.973c.542-.939.861-2.127.861-3.745 0-2.72-.681-5.357-2.084-7.45-1.282-1.912-2.957-2.93-4.716-2.93-1.047 0-2.088.467-3.053 1.308-.652.57-1.257 1.29-1.82 2.05-.69-.875-1.335-1.547-1.958-2.056-1.182-.966-2.315-1.303-3.454-1.303zm10.16 2.053c1.147 0 2.188.758 2.992 1.999 1.132 1.748 1.647 4.195 1.647 6.4 0 1.548-.368 2.9-1.839 2.9-.58 0-1.027-.23-1.664-1.004-.496-.601-1.343-1.878-2.832-4.358l-.617-1.028a44.908 44.908 0 0 0-1.255-1.98c.07-.109.141-.224.211-.327 1.12-1.667 2.118-2.602 3.358-2.602zm-10.201.553c1.265 0 2.058.791 2.675 1.446.307.327.737.871 1.234 1.579l-1.02 1.566c-.757 1.163-1.882 3.017-2.837 4.338-1.191 1.649-1.81 1.817-2.486 1.817-.524 0-1.038-.237-1.383-.794-.263-.426-.464-1.13-.464-2.046 0-2.221.63-4.535 1.66-6.088.454-.687.964-1.226 1.533-1.533a2.264 2.264 0 0 1 1.088-.285z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span className="sr-only">Login with Meta</span>
+                </Button>
+              </div>
+              <div className="text-center text-sm">
+                Don&apos;t have an account?{' '}
+                <a href="#" className="underline underline-offset-4">
+                  Sign up
+                </a>
+              </div>
+            </div>
+          </form>
+          <div className="relative hidden bg-muted md:block">
+            <img
+              src="/placeholder.svg"
+              alt="Image"
+              className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.2] dark:grayscale"
+            />
+          </div>
+        </CardContent>
+      </Card>
+      <div className="text-balance text-center text-xs text-muted-foreground [&_a]:underline [&_a]:underline-offset-4 hover:[&_a]:text-primary">
+        By clicking continue, you agree to our <a href="#">Terms of Service</a> and <a href="#">Privacy Policy</a>.
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useAuth } from '../context/AuthContext';
+
+export default function Navbar({ favoriteDriver, onFavoriteChange, onSave }) {
+  const { logout } = useAuth();
+  return (
+    <div className="flex items-center justify-between bg-gray-900 p-4 rounded">
+      <div className="flex items-center space-x-2">
+        <input
+          className="text-black p-2"
+          value={favoriteDriver}
+          onChange={(e) => onFavoriteChange(e.target.value)}
+          placeholder="Driver number e.g. 1"
+        />
+        <button className="bg-red-600 px-3 py-2 rounded" onClick={onSave}>
+          Save
+        </button>
+      </div>
+      <button
+        className="bg-gray-700 px-3 py-2 rounded"
+        onClick={logout}
+      >
+        Logout
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/TelemetryPanel.jsx
+++ b/frontend/src/components/TelemetryPanel.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 export default function TelemetryPanel({ telemetry }) {
-  if (!telemetry) return <div className="bg-gray-800 p-4 rounded">Waiting for telemetry...</div>;
+  if (!telemetry)
+    return <div className="bg-gray-800 p-4 rounded h-full">Waiting for telemetry...</div>;
   return (
-    <div className="grid grid-cols-5 gap-4 bg-gray-800 p-4 rounded">
+    <div className="grid grid-cols-5 gap-4 bg-gray-800 p-4 rounded h-full">
       <div>Speed: {telemetry.speed}</div>
       <div>RPM: {telemetry.rpm}</div>
       <div>Throttle: {telemetry.throttle}</div>

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+export const Button = React.forwardRef(({ className, variant = 'default', ...props }, ref) => {
+  const variants = {
+    default: 'bg-red-600 text-white hover:bg-red-700',
+    outline: 'border border-gray-300 bg-transparent hover:bg-gray-100 text-gray-900'
+  };
+  return (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors',
+        'focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none',
+        variants[variant],
+        className
+      )}
+      {...props}
+    />
+  );
+});
+Button.displayName = 'Button';

--- a/frontend/src/components/ui/card.jsx
+++ b/frontend/src/components/ui/card.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+export function Card({ className, ...props }) {
+  return <div className={cn('rounded-lg border bg-white text-black shadow', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }) {
+  return <div className={cn('p-6', className)} {...props} />;
+}

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+export const Input = React.forwardRef(({ className, type = 'text', ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      ref={ref}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-black placeholder:text-gray-500',
+        'focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2',
+        className
+      )}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';

--- a/frontend/src/components/ui/label.jsx
+++ b/frontend/src/components/ui/label.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+export const Label = React.forwardRef(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn('text-sm font-medium leading-none', className)}
+    {...props}
+  />
+));
+Label.displayName = 'Label';

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,0 +1,3 @@
+export function cn(...classes) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,47 +1,10 @@
-import React, { useState } from 'react';
-import { useAuth } from '../context/AuthContext';
+import React from 'react';
+import LoginForm from '../components/LoginForm';
 
 export default function Login() {
-  const { login } = useAuth();
-  const [username, setUsername] = useState('demo');
-  const [password, setPassword] = useState('password');
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    const res = await fetch('http://localhost:3000/api/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
-    });
-    if (res.ok) {
-      const data = await res.json();
-      login(data.token);
-    } else {
-      alert('Login failed');
-    }
-  };
-
   return (
-    <div className="flex items-center justify-center h-screen">
-      <form onSubmit={handleSubmit} className="bg-gray-800 p-8 rounded space-y-4">
-        <h1 className="text-xl">Login</h1>
-        <input
-          className="w-full p-2 text-black"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          placeholder="Username"
-        />
-        <input
-          className="w-full p-2 text-black"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder="Password"
-        />
-        <button className="bg-red-600 px-4 py-2 rounded" type="submit">
-          Sign in
-        </button>
-      </form>
+    <div className="flex items-center justify-center min-h-screen">
+      <LoginForm />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable navbar component handling favorite driver selection and logout
- integrate navbar into dashboard for streamlined layout
- display selected driver stats in bento-style grid
- implement styled login form with reusable UI primitives

## Testing
- `cd frontend && npm test`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f8e3372ac832eb27a37a20e375a3a